### PR TITLE
Relative path and others

### DIFF
--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
@@ -11,7 +11,7 @@ namespace Staple.EditorScripts
     {
         // Future ready: Implement sprite settings sets;
         public List<SpriteSettings> SettingsSets;
-        public const string DefaultPath = "Assets/Editor/QuickSpriteSettings/DefaultSpriteSettings.asset";
+        public const string DefaultFilename = "DefaultSpriteSettings.asset";
 
         void OnEnable()
         {

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
@@ -16,6 +16,22 @@ namespace Staple.EditorScripts
                 configEditor = Editor.CreateEditor (config);
             }
         }
+        void OnEnable ()
+        {
+            // Reload config if this window gets rebuilt (which happens when recompiling with an open window)
+            ReloadConfig ();
+        }
+        
+        void ReloadConfig ()
+        {
+            if (config != null) 
+            {
+                config = AssetDatabase.LoadAssetAtPath<SpriteSettingsConfig> (AssetDatabase.GetAssetPath (config));
+                if (this.config != null ) {
+                    configEditor = Editor.CreateEditor (config);
+                }
+            }
+        }
 
         void OnInspectorUpdate()
         {

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
@@ -9,12 +9,10 @@ namespace Staple.EditorScripts
         Editor configEditor;
         private SpriteSettingsConfig config;
         private Vector2 scrollPos;
-
-        void OnEnable()
-        {
-            config = AssetDatabase.LoadAssetAtPath(SpriteSettingsConfig.DefaultPath,
-                 typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
-            if (config != null) {
+        
+        public void SetConfig (SpriteSettingsConfig config) {
+            this.config = config;
+            if (this.config != null) {
                 configEditor = Editor.CreateEditor (config);
             }
         }
@@ -26,7 +24,11 @@ namespace Staple.EditorScripts
 
         void OnGUI()
         {
-            if (config == null) return;
+            if (config == null) {
+                EditorGUILayout.HelpBox ("Trying to view Saved SpriteSettings but no settings file exists.", 
+                    MessageType.Error);
+                return;
+            }
             
             EditorGUILayout.BeginVertical(EditorStyles.inspectorDefaultMargins);
             scrollPos = EditorGUILayout.BeginScrollView (scrollPos);
@@ -39,6 +41,9 @@ namespace Staple.EditorScripts
         }
         public void SelectSetting (int settingIndex)
         {
+            if (configEditor == null) {
+                return;
+            }
             ((SpriteSettingsConfigEditor)configEditor).SelectSetting (settingIndex);
         }
     }

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
@@ -36,6 +36,7 @@ namespace Staple.EditorScripts
         private bool changePackingTag;
         private SpriteSettingsConfig config;
         private Vector2 bodyScrollPos;
+        SpriteSettingsConfigWindow configWindow;
 
         void OnEnable()
         {
@@ -92,6 +93,10 @@ namespace Staple.EditorScripts
 				}
                 
                 Close();
+                if (configWindow != null) 
+                {
+                    configWindow.Close ();
+                }
             }
             GUI.backgroundColor = defaultBg;
         }
@@ -130,9 +135,9 @@ namespace Staple.EditorScripts
         
         void ShowConfigWindow (int indexToFocus)
         {
-                var window = EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
-                window.SetConfig (config);
-                window.SelectSetting (indexToFocus);
+                configWindow = EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
+                configWindow.SetConfig (config);
+                configWindow.SelectSetting (indexToFocus);
         }
         
         void DrawSaveSettingSelect ()

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
@@ -39,16 +39,8 @@ namespace Staple.EditorScripts
 
         void OnEnable()
         {
-            LoadOrCreateConfig ();
-        }
-        
-        void LoadOrCreateConfig ()
-        {
             config = AssetDatabase.LoadAssetAtPath(SpriteSettingsConfig.DefaultPath,
                 typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
-
-            if (config == null)
-                config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(SpriteSettingsConfig.DefaultPath);
         }
 
         void OnInspectorUpdate()
@@ -111,14 +103,19 @@ namespace Staple.EditorScripts
             EditorGUILayout.LabelField ("Create a Saved SpriteSetting to start applying SpriteSettings.");
             if (GUILayout.Button ("Create Setting")) {
                 if (config == null) {
-                    LoadOrCreateConfig ();
+                    CreateConfig ();
                 }
                 EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
-                if (config != null && config.SettingsSets.Count == 0) {
+                if (config.SettingsSets.Count == 0) {
                     config.AddDefaultSpriteSetting ();
                 }
             }
             EditorGUILayout.Space ();
+        }
+        
+        void CreateConfig ()
+        {
+            config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(SpriteSettingsConfig.DefaultPath);
         }
         
         void DrawSaveSettingSelect ()

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
@@ -39,8 +39,7 @@ namespace Staple.EditorScripts
 
         void OnEnable()
         {
-            config = AssetDatabase.LoadAssetAtPath(SpriteSettingsConfig.DefaultPath,
-                typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
+            config = AssetDatabase.LoadAssetAtPath(GetPathToConfig (), typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
         }
 
         void OnInspectorUpdate()
@@ -105,7 +104,9 @@ namespace Staple.EditorScripts
                 if (config == null) {
                     CreateConfig ();
                 }
-                EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
+                
+                ShowConfigWindow (0);
+                
                 if (config.SettingsSets.Count == 0) {
                     config.AddDefaultSpriteSetting ();
                 }
@@ -115,7 +116,23 @@ namespace Staple.EditorScripts
         
         void CreateConfig ()
         {
-            config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(SpriteSettingsConfig.DefaultPath);
+            config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(GetPathToConfig ());
+        }
+        
+        string GetPathToConfig ()
+        {
+            MonoScript script = MonoScript.FromScriptableObject (this);
+            string scriptPath = AssetDatabase.GetAssetPath (script);
+            string scriptDirectory = System.IO.Path.GetDirectoryName (scriptPath);
+            string filename = SpriteSettingsConfig.DefaultFilename;
+            return scriptDirectory + System.IO.Path.DirectorySeparatorChar + filename;
+        }
+        
+        void ShowConfigWindow (int indexToFocus)
+        {
+                var window = EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
+                window.SetConfig (config);
+                window.SelectSetting (indexToFocus);
         }
         
         void DrawSaveSettingSelect ()
@@ -135,9 +152,7 @@ namespace Staple.EditorScripts
                                                         savedSetNames, savedSetIndeces);
             currentSelectedSettings = config.SettingsSets [selectedSettingIndex];
             if (GUILayout.Button ("Edit", GUILayout.MaxWidth(80.0f))) {
-                SpriteSettingsConfigWindow window = 
-                    EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
-                window.SelectSetting (selectedSettingIndex);
+                ShowConfigWindow (selectedSettingIndex);
             }
             EditorGUILayout.EndHorizontal ();
         }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -8,6 +8,7 @@ PlayerSettings:
   defaultScreenOrientation: 4
   targetDevice: 2
   targetResolution: 0
+  useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: DefaultCompany
   productName: SpriteSettingsUtility
@@ -28,6 +29,7 @@ PlayerSettings:
   androidShowActivityIndicatorOnLoading: -1
   iosAppInBackgroundBehavior: 0
   displayResolutionDialog: 1
+  iosAllowHTTPDownload: 1
   allowedAutorotateToPortrait: 1
   allowedAutorotateToPortraitUpsideDown: 1
   allowedAutorotateToLandscapeRight: 1
@@ -60,11 +62,23 @@ PlayerSettings:
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0
+  n3dsDisableStereoscopicView: 0
+  n3dsEnableSharedListOpt: 1
+  n3dsEnableVSync: 0
   xboxOneResolution: 0
   ps3SplashScreen: {fileID: 0}
   videoMemoryForVertexBuffers: 0
   psp2PowerMode: 0
   psp2AcquireBGM: 1
+  wiiUTVResolution: 0
+  wiiUGamePadMSAA: 1
+  wiiUSupportsNunchuk: 0
+  wiiUSupportsClassicController: 0
+  wiiUSupportsBalanceBoard: 0
+  wiiUSupportsMotionPlus: 0
+  wiiUSupportsProController: 0
+  wiiUAllowScreenCapture: 1
+  wiiUControllerCount: 0
   m_SupportedAspectRatios:
     4:3: 1
     5:4: 1
@@ -84,14 +98,19 @@ PlayerSettings:
   AndroidPreferredInstallLocation: 1
   aotOptions: 
   apiCompatibilityLevel: 2
+  stripEngineCode: 1
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
+  iPhoneBuildNumber: 0
   ForceInternetPermission: 0
   ForceSDCardPermission: 0
   CreateWallpaper: 0
   APKExpansionFiles: 0
   preloadShaders: 0
   StripUnusedMeshComponents: 0
+  VertexChannelCompressionMask:
+    serializedVersion: 2
+    m_Bits: 238
   iPhoneSdkVersion: 988
   iPhoneTargetOSVersion: 22
   uIPrerenderedIcon: 0
@@ -118,6 +137,15 @@ PlayerSettings:
   iOSLaunchScreenFillPct: 1
   iOSLaunchScreenSize: 100
   iOSLaunchScreenCustomXibPath: 
+  iOSLaunchScreeniPadType: 0
+  iOSLaunchScreeniPadImage: {fileID: 0}
+  iOSLaunchScreeniPadBackgroundColor:
+    serializedVersion: 2
+    rgba: 0
+  iOSLaunchScreeniPadFillPct: 100
+  iOSLaunchScreeniPadSize: 100
+  iOSLaunchScreeniPadCustomXibPath: 
+  iOSDeviceRequirements: []
   AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -137,6 +165,23 @@ PlayerSettings:
   m_BuildTargetGraphicsAPIs: []
   webPlayerTemplate: APPLICATION:Default
   m_TemplateCustomTags: {}
+  wiiUTitleID: 0005000011000000
+  wiiUGroupID: 00010000
+  wiiUCommonSaveSize: 4096
+  wiiUAccountSaveSize: 2048
+  wiiUOlvAccessKey: 0
+  wiiUTinCode: 0
+  wiiUJoinGameId: 0
+  wiiUJoinGameModeMask: 0000000000000000
+  wiiUCommonBossSize: 0
+  wiiUAccountBossSize: 0
+  wiiUAddOnUniqueIDs: []
+  wiiUMainThreadStackSize: 3072
+  wiiULoaderThreadStackSize: 1024
+  wiiUSystemHeapSize: 128
+  wiiUTVStartupScreen: {fileID: 0}
+  wiiUGamePadStartupScreen: {fileID: 0}
+  wiiUProfilerLibPath: 
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
@@ -187,15 +232,20 @@ PlayerSettings:
   ps4BackgroundImagePath: 
   ps4StartupImagePath: 
   ps4SaveDataImagePath: 
+  ps4SdkOverride: 
   ps4BGMPath: 
   ps4ShareFilePath: 
+  ps4ShareOverlayImagePath: 
+  ps4PrivacyGuardImagePath: 
   ps4NPtitleDatPath: 
   ps4RemotePlayKeyAssignment: -1
+  ps4RemotePlayKeyMappingDir: 
   ps4EnterButtonAssignment: 1
   ps4ApplicationParam1: 0
   ps4ApplicationParam2: 0
   ps4ApplicationParam3: 0
   ps4ApplicationParam4: 0
+  ps4DownloadDataSize: 0
   ps4GarlicHeapSize: 2048
   ps4Passcode: QKhin2EwanevsIbaa1BGOSek9jI5rMy0
   ps4pnSessions: 1
@@ -203,6 +253,14 @@ PlayerSettings:
   ps4pnFriends: 1
   ps4pnGameCustomData: 1
   playerPrefsSupport: 0
+  ps4ReprojectionSupport: 0
+  ps4UseAudio3dBackend: 0
+  ps4Audio3dVirtualSpeakerCount: 14
+  ps4attribUserManagement: 0
+  ps4attribMoveSupport: 0
+  ps4attrib3DSupport: 0
+  ps4attribShareSupport: 0
+  ps4IncludedModules: []
   monoEnv: 
   psp2Splashimage: {fileID: 0}
   psp2NPTrophyPackPath: 
@@ -342,6 +400,17 @@ PlayerSettings:
   tizenSigningProfileName: 
   tizenGPSPermissions: 0
   tizenMicrophonePermissions: 0
+  n3dsUseExtSaveData: 0
+  n3dsCompressStaticMem: 1
+  n3dsExtSaveDataNumber: 0x12345
+  n3dsStackSize: 131072
+  n3dsTargetPlatform: 2
+  n3dsRegion: 7
+  n3dsMediaSize: 0
+  n3dsLogoStyle: 3
+  n3dsTitle: GameName
+  n3dsProductCode: 
+  n3dsApplicationId: 0xFF3FF
   stvDeviceAddress: 
   stvProductDescription: 
   stvProductAuthor: 
@@ -367,17 +436,23 @@ PlayerSettings:
   XboxOneAllowedProductIds: []
   XboxOnePersistentLocalStorageSize: 0
   intPropertyNames:
+  - Android::ScriptingBackend
+  - Standalone::ScriptingBackend
   - WebGL::ScriptingBackend
   - WebGL::audioCompressionFormat
   - WebGL::exceptionSupport
   - WebGL::memorySize
   - iOS::Architecture
+  - iOS::EnableIncrementalBuildSupportForIl2cpp
   - iOS::ScriptingBackend
+  Android::ScriptingBackend: 0
+  Standalone::ScriptingBackend: 0
   WebGL::ScriptingBackend: 1
   WebGL::audioCompressionFormat: 4
   WebGL::exceptionSupport: 0
   WebGL::memorySize: 256
   iOS::Architecture: 2
+  iOS::EnableIncrementalBuildSupportForIl2cpp: 0
   iOS::ScriptingBackend: 0
   boolPropertyNames:
   - WebGL::analyzeBuildSize
@@ -391,11 +466,12 @@ PlayerSettings:
   stringPropertyNames:
   - WebGL::emscriptenArgs
   - WebGL::template
+  - additionalIl2CppArgs::additionalIl2CppArgs
   WebGL::emscriptenArgs: 
   WebGL::template: APPLICATION:Default
+  additionalIl2CppArgs::additionalIl2CppArgs: 
   firstStreamedSceneWithResources: 0
   cloudProjectId: 
-  projectId: 
   projectName: 
   organizationId: 
   cloudEnabled: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 5.1.1f1
+m_EditorVersion: 5.2.2f1
 m_StandardAssetsVersion: 0

--- a/ProjectSettings/UnityAdsSettings.asset
+++ b/ProjectSettings/UnityAdsSettings.asset
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!292 &1
+UnityAdsSettings:
+  m_ObjectHideFlags: 0
+  m_Enabled: 0
+  m_InitializeOnStartup: 1
+  m_TestMode: 0
+  m_EnabledPlatforms: 4294967295
+  m_IosGameId: 
+  m_AndroidGameId: 

--- a/ProjectSettings/UnityAnalyticsManager.asset
+++ b/ProjectSettings/UnityAnalyticsManager.asset
@@ -1,0 +1,10 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!303 &1
+UnityAnalyticsManager:
+  m_ObjectHideFlags: 0
+  m_Enabled: 0
+  m_InitializeOnStartup: 1
+  m_TestMode: 0
+  m_TestEventUrl: 
+  m_TestConfigUrl: 


### PR DESCRIPTION
- Removes hardcoded path to the config. This made it hard for users to move the assets within their projects (which is admittedly a bad idea, but still shouldn't error). Previously this resulted in an error trying to create the scriptable object in a folder that didn't exist.
- Closes config window in addition to the QuickSettings window when you "apply" settings.
- Adds a correct Default element when you have an empty list 
  *\* This basically addressed a bug where invalid elements were added when you delete all the elements in the Settings, then create one through the +/-, not through the button in the QuickSettings window.
- Fixes a NullReference error that spewed when recompiling code with the Config window open. I think it somehow maintained reference to the Config file, then when trying to re-render its Editor, some internal Reflection operations went wrong. To fix it I re-load the config OnEnable, if it's valid. Seems to work.
